### PR TITLE
Fix status code being set twice

### DIFF
--- a/src/Pages/ManagementBasePage.cs
+++ b/src/Pages/ManagementBasePage.cs
@@ -198,6 +198,8 @@ namespace Hangfire.Dashboard.Management.v2.Pages
 							}
 					}
 
+					context.Response.ContentType = "application/json";
+
 					if (!string.IsNullOrEmpty(jobLink))
 					{
 						context.Response.StatusCode = (int)HttpStatusCode.OK;

--- a/src/Support/CommandWithResponseDispatcher.cs
+++ b/src/Support/CommandWithResponseDispatcher.cs
@@ -21,16 +21,8 @@ namespace Hangfire.Dashboard.Management.v2.Support
                 response.StatusCode = 405;
                 return (Task)Task.FromResult<bool>(false);
             }
-            if (this._command(context))
-            {
-                response.StatusCode = 200;
-                response.ContentType = "application/json";
-            }
-            else
-            {
-                response.StatusCode = 422;
-            }
-            
+
+            this._command(context);
             return (Task)Task.FromResult<bool>(true);
         }
     }


### PR DESCRIPTION
Fix an issue where the code tries to set the status code twice which throws an exception.

This can easily go unnoticed but I have a middleware that catches any unhandled exceptions, logs to disk and the returns a 500. This breaks the management page (can't visit the "see job" link).

`System.InvalidOperationException: StatusCode cannot be set because the response has already started.`

```
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ThrowResponseAlreadyStartedException(String value)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.set_StatusCode(Int32 value)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.Microsoft.AspNetCore.Http.Features.IHttpResponseFeature.set_StatusCode(Int32 value)
   at Microsoft.AspNetCore.Http.DefaultHttpResponse.set_StatusCode(Int32 value)
   at Hangfire.Dashboard.AspNetCoreDashboardResponse.set_StatusCode(Int32 value)
   at Hangfire.Dashboard.Management.v2.Support.CommandWithResponseDispatcher.Dispatch(DashboardContext context)
   at Hangfire.Dashboard.AspNetCoreDashboardMiddleware.<Invoke>d__5.MoveNext()
```