### PR TITLE
Fixed issue when an int parameter is set to "isRequired";

### DIFF
--- a/src/Pages/ManagementBasePage.cs
+++ b/src/Pages/ManagementBasePage.cs
@@ -86,12 +86,13 @@ namespace Hangfire.Dashboard.Management.v2.Pages
 						}
 						else if (parameterInfo.ParameterType == typeof(int))
 						{
-							if (formInput != null) item = int.Parse(formInput);
-							if (displayInfo.IsRequired && string.IsNullOrWhiteSpace((string)item))
+							int intNumber;
+							if (int.TryParse(formInput, out intNumber) == false)
 							{
-								errorMessage = $"{parameterInfo.Name} is required.";
+								errorMessage = $"{parameterInfo.Name} was not in a correct format.";
 								break;
 							}
+							item = intNumber;
 						}
 						else if (parameterInfo.ParameterType == typeof(DateTime))
 						{


### PR DESCRIPTION
When the "isRequired" attribute is set to an int parameter, the application was throwing an unknown error due to a bug with the logic that was checking if the parameter was required.
I've removed that logic since the "int" type would not require the "isRequired" attribute, but in case we, as developers add it to an int parameter, we don't prevent the job from saving and don't get the confusing error message.
Also, with these changes, if the end-user cleans up the numeric input, instead of getting the "unknown error" message, we get a more clear message that the numeric field is in the wrong format.