### PR TITLE
Remove toLocalTime - double conversion

### DIFF
--- a/src/Pages/ManagementBasePage.cs
+++ b/src/Pages/ManagementBasePage.cs
@@ -184,7 +184,7 @@ namespace Hangfire.Dashboard.Management.v2.Pages
 									}
 									try
 									{
-										var jobId = client.Create(job, new ScheduledState(dt.ToLocalTime()));//Queue
+										var jobId = client.Create(job, new ScheduledState(dt));//Queue
 										jobLink = new UrlHelper(context).JobDetails(jobId);
 									}
 									catch (Exception e)

--- a/src/Pages/ManagementBasePage.cs
+++ b/src/Pages/ManagementBasePage.cs
@@ -184,7 +184,7 @@ namespace Hangfire.Dashboard.Management.v2.Pages
 									}
 									try
 									{
-										var jobId = client.Create(job, new ScheduledState(dt));//Queue
+										var jobId = client.Create(job, new ScheduledState(dt.ToUniversalTime()));//Queue
 										jobLink = new UrlHelper(context).JobDetails(jobId);
 									}
 									catch (Exception e)


### PR DESCRIPTION
When scheduling jobs with the date picker the input is already in local time so calling ToLocalTime() converted it again causing a double time zone conversion. This change stores the date directly in local time.